### PR TITLE
updating simulation rmls

### DIFF
--- a/210PoFromSample.rml
+++ b/210PoFromSample.rml
@@ -23,10 +23,10 @@
           </source>
         </generator>
 
-        <storage sensitiveVolume="gas">
+        <detector>
             <parameter name="energyRange" value="(1,8)MeV"/>
-            <activeVolume name="gas" chance="1" maxStepSize="0.01mm"/> 
-        </storage>
+            <volume name="gas" sensitive="true" maxStepSize="0.01mm"/>
+        </detector>
     </TRestGeant4Metadata>
 
   <TRestGeant4PhysicsLists name="default" file="common/physics.xml" />

--- a/214PoFromMylar.rml
+++ b/214PoFromMylar.rml
@@ -22,10 +22,10 @@
           </source>
         </generator>
 
-        <storage sensitiveVolume="gas">
+        <detector>
             <parameter name="energyRange" value="(1,8)MeV"/>
-            <activeVolume name="gas" chance="1" maxStepSize="0.01mm"/> 
-        </storage>
+            <volume name="gas" sensitive="true" maxStepSize="0.01mm"/>
+        </detector>
     </TRestGeant4Metadata>
 
   <TRestGeant4PhysicsLists name="default" file="common/physics.xml" /> 

--- a/218PoFromMylar.rml
+++ b/218PoFromMylar.rml
@@ -22,10 +22,10 @@
           </source>
         </generator>
 
-        <storage sensitiveVolume="gas">
+        <detector>
             <parameter name="energyRange" value="(1,8)MeV"/>
-            <activeVolume name="gas" chance="1" maxStepSize="0.01mm"/> 
-        </storage>
+            <volume name="gas" sensitive="true" maxStepSize="0.01mm"/>
+        </detector>
     </TRestGeant4Metadata>
 
   <TRestGeant4PhysicsLists name="default" file="common/physics.xml" /> 

--- a/222RnFromGas.rml
+++ b/222RnFromGas.rml
@@ -22,10 +22,10 @@
           </source>
         </generator>
 
-        <storage sensitiveVolume="gas">
+        <detector>
             <parameter name="energyRange" value="(1,8)MeV"/>
-            <activeVolume name="gas" chance="1" maxStepSize="0.01mm"/> 
-        </storage>
+            <volume name="gas" sensitive="true" maxStepSize="0.01mm"/>
+        </detector>
     </TRestGeant4Metadata>
 
   <TRestGeant4PhysicsLists name="default" file="common/physics.xml" /> 

--- a/241AmFromSource.rml
+++ b/241AmFromSource.rml
@@ -23,10 +23,10 @@
           </source>
         </generator>
 
-        <storage sensitiveVolume="gas">
+        <detector>
             <parameter name="energyRange" value="(1,8)MeV"/>
-            <activeVolume name="gas" chance="1" maxStepSize="0.01mm"/> 
-        </storage>
+            <volume name="gas" sensitive="true" maxStepSize="0.01mm"/>
+        </detector>
     </TRestGeant4Metadata>
 
   <TRestGeant4PhysicsLists name="default" file="common/physics.xml" /> 


### PR DESCRIPTION
I have updated the ``<detector>`` section

Some changes that we can include:

- [ ] Generating the alphas by the decay of each isotope. We can configure via rml if we want to simulate the full chain or stop at some point ([restG4-132](https://github.com/rest-for-physics/restG4/pull/132)). So, for example, if we want to simulate the decay of 222Rn->218Po from the gas the rml section for the particle generator should be like this:
```
 <generator type="volume" shape="gdml" from="gasVolume">            
      <source particle="Rn222" fullChain="off">
               <angular type="isotropic"/>
               <energy type="mono" energy="0keV"/>
       </source>
</generator>
```
- [ ] If we want to access to the TRestGeant4PhysicsLists object after the simulation, we couldn't because we are naming it as "default". We can ommit the name part `<TRestGeant4PhysicsLists name="default" file="common/physics.xml" /> `
- [ ] Also, a more practical thing, do you want to have the rml divided like it is now or prefer to have everything in the same file?